### PR TITLE
return the request object

### DIFF
--- a/chef.js
+++ b/chef.js
@@ -49,7 +49,7 @@ function req(method, uri, body, _) {
         headers['X-Ops-Authorization-' + ++line] = hash
     });
 
-    request(uri, {
+    return request(uri, {
         method: method,
         headers: headers,
         json: true,
@@ -64,7 +64,7 @@ function req(method, uri, body, _) {
 var methods = ['delete', 'get', 'patch', 'post', 'put'];
 methods.forEach(function (method) {
     Chef.prototype[method] = function (uri, body, _) {
-        req.call(this, method, uri, body, _);
+        return req.call(this, method, uri, body, _);
     }
 });
 


### PR DESCRIPTION
This makes it so requests return the request object, so you can take advantage of Node streams. Let's say you have an Express app; you can do something like:

``` js
app.get('/proxy/nodes', function (req, res) {
    client.get('/nodes').pipe(res);
}
```
