### PR TITLE
Fix authentication with query strings

### DIFF
--- a/chef/authenticate.js
+++ b/chef/authenticate.js
@@ -14,7 +14,7 @@ function bodyHash(body) {
 
 // Hash the path of the uri
 function pathHash(uri) {
-    return sha1(url.parse(uri).path);
+    return sha1(url.parse(uri).pathname);
 }
 
 // Generate a timestamp, formatted how Chef wants it

--- a/tests/chef/authenticate.js
+++ b/tests/chef/authenticate.js
@@ -7,7 +7,7 @@ describe('authenticate', function () {
     beforeEach(function () {
         this.clock = sinon.useFakeTimers(0);
         this.client = { user: 'test', key: key };
-        this.options = { body: '', uri: 'https://example.com/test' };
+        this.options = { body: '', uri: 'https://example.com/test?query=string' };
         this.headers = authenticate(this.client, this.options);
     });
 


### PR DESCRIPTION
When using a query string with a GET request (for instance when
doing a search), authentication breaks because the query string is
included in the input for the Hashed Path authentication header.

Per the documentation for the Chef API, query strings are not
supposed to be included.

  cf. https://docs.chef.io/api_chef_server.html#header_format

Replacing the call to url#path with url#pathname fixes the issue.